### PR TITLE
Retry on deadlock to prevent alert noise take 2

### DIFF
--- a/delayed_job_active_record.gemspec
+++ b/delayed_job_active_record.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |spec|
   spec.require_paths  = ['lib']
   spec.summary        = 'ActiveRecord backend for DelayedJob'
   spec.test_files     = Dir.glob("spec/**/*")
-  spec.version        = '4.0.0.sw.0'
+  spec.version        = '4.0.0.sw.1'
 end

--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -23,6 +23,10 @@ module Delayed
           end
         end
 
+        def destroy
+          self.class.retry_on_deadlock(10) { super }
+        end
+
         def self.enqueue(*args)
           options = args.extract_options!
           payload_object = options[:payload_object] || args[0]


### PR DESCRIPTION
@kbarrette - Need to retry when we see a deadlock on delete as well.
