### PR TITLE
Use a 'singleton' field rather than the 'queue' field for singletons

### DIFF
--- a/delayed_job_active_record.gemspec
+++ b/delayed_job_active_record.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |spec|
   spec.require_paths  = ['lib']
   spec.summary        = 'ActiveRecord backend for DelayedJob'
   spec.test_files     = Dir.glob("spec/**/*")
-  spec.version        = '4.0.0.sw.1'
+  spec.version        = '4.0.0.sw.2'
 end

--- a/lib/generators/delayed_job/singleton_queues_generator.rb
+++ b/lib/generators/delayed_job/singleton_queues_generator.rb
@@ -1,0 +1,22 @@
+require 'generators/delayed_job/delayed_job_generator'
+require 'generators/delayed_job/next_migration_version'
+require 'rails/generators/migration'
+require 'rails/generators/active_record'
+
+# Extend the DelayedJobGenerator so that it creates an AR migration
+module DelayedJob
+  class SingletonQueuesGenerator < ::DelayedJobGenerator
+    include Rails::Generators::Migration
+    extend NextMigrationVersion
+
+    self.source_paths << File.join(File.dirname(__FILE__), 'templates')
+
+    def create_migration_file
+      migration_template 'singleton_queues_migration.rb', 'db/migrate/add_singleton_to_delayed_jobs.rb'
+    end
+
+    def self.next_migration_number dirname
+      ActiveRecord::Generators::Base.next_migration_number dirname
+    end
+  end
+end

--- a/lib/generators/delayed_job/templates/singleton_queues_migration.rb
+++ b/lib/generators/delayed_job/templates/singleton_queues_migration.rb
@@ -1,0 +1,10 @@
+class AddSingletonToDelayedJobs < ActiveRecord::Migration
+  def self.up
+    add_column :delayed_jobs, :singleton, :string
+    execute "UPDATE delayed_jobs SET singleton = substr(queue, #{'singleton_'.length + 1}, 255) WHERE queue like 'singleton_%'"
+  end
+
+  def self.down
+    remove_column :delayed_jobs, :singleton
+  end
+end

--- a/spec/delayed/backend/singleton_queue_spec.rb
+++ b/spec/delayed/backend/singleton_queue_spec.rb
@@ -36,9 +36,9 @@ describe "Singleton Job Queue" do
       Delayed::Job.reserve(worker2)
 
       # There should be two jobs on the queue, one locked and one not locked
-      expect(Delayed::Job.where(queue: "singleton_#{queue_name}").count).to eq(2)
-      expect(Delayed::Job.where(queue: "singleton_#{queue_name}", locked_by: worker1.name).count).to eq(1)
-      expect(Delayed::Job.where(queue: "singleton_#{queue_name}", locked_by: nil).count).to eq(1)
+      expect(Delayed::Job.where(singleton: queue_name).count).to eq(2)
+      expect(Delayed::Job.where(singleton: queue_name, locked_by: worker1.name).count).to eq(1)
+      expect(Delayed::Job.where(singleton: queue_name, locked_by: nil).count).to eq(1)
     end
 
     context "when one of the jobs is locked" do
@@ -56,9 +56,9 @@ describe "Singleton Job Queue" do
           Delayed::Job.reserve(worker2)
 
           # There should be two jobs on the queue, both locked and one failed
-          expect(Delayed::Job.where(queue: "singleton_#{queue_name}").count).to eq(2)
-          expect(Delayed::Job.where(queue: "singleton_#{queue_name}", locked_by: worker1.name).count).to eq(2)
-          expect(Delayed::Job.where(queue: "singleton_#{queue_name}", failed_at: failure_time).count).to eq(1)
+          expect(Delayed::Job.where(singleton: queue_name).count).to eq(2)
+          expect(Delayed::Job.where(singleton: queue_name, locked_by: worker1.name).count).to eq(2)
+          expect(Delayed::Job.where(singleton: queue_name, failed_at: failure_time).count).to eq(1)
         end
       end
 
@@ -72,9 +72,9 @@ describe "Singleton Job Queue" do
           Delayed::Job.reserve(worker2)
 
           # There should be two jobs on the queue, one locked and one not locked
-          expect(Delayed::Job.where(queue: "singleton_#{queue_name}").count).to eq(2)
-          expect(Delayed::Job.where(queue: "singleton_#{queue_name}", locked_by: worker1.name).count).to eq(1)
-          expect(Delayed::Job.where(queue: "singleton_#{queue_name}", locked_by: nil).count).to eq(1)
+          expect(Delayed::Job.where(singleton: queue_name).count).to eq(2)
+          expect(Delayed::Job.where(singleton: queue_name, locked_by: worker1.name).count).to eq(1)
+          expect(Delayed::Job.where(singleton: queue_name, locked_by: nil).count).to eq(1)
         end
       end
 
@@ -88,17 +88,17 @@ describe "Singleton Job Queue" do
           Delayed::Job.reserve(worker2)
 
           # There should be three jobs on the queue, one not locked and one from each queue locked
-          expect(Delayed::Job.where(queue: "singleton_#{queue_name}").count).to eq(2)
-          expect(Delayed::Job.where(queue: "singleton_#{queue_name}", locked_by: worker1.name).count).to eq(1)
-          expect(Delayed::Job.where(queue: "singleton_#{queue_name}", locked_by: nil).count).to eq(1)
-          expect(Delayed::Job.where(queue: "singleton_#{different_queue_name}").count).to eq(1)
-          expect(Delayed::Job.where(queue: "singleton_#{different_queue_name}", locked_by: worker2.name).count).to eq(1)
+          expect(Delayed::Job.where(singleton: queue_name).count).to eq(2)
+          expect(Delayed::Job.where(singleton: queue_name, locked_by: worker1.name).count).to eq(1)
+          expect(Delayed::Job.where(singleton: queue_name, locked_by: nil).count).to eq(1)
+          expect(Delayed::Job.where(singleton: different_queue_name).count).to eq(1)
+          expect(Delayed::Job.where(singleton: different_queue_name, locked_by: worker2.name).count).to eq(1)
         end
       end
 
       context "with a non-singleton-queue-job" do
         before do
-          Delayed::Job.enqueue(payload_object: TestNonSingleton.new, queue: different_queue_name)
+          Delayed::Job.enqueue(payload_object: TestNonSingleton.new, singleton: different_queue_name)
         end
 
         it "will reserve the non-singleton-queue job" do
@@ -106,11 +106,11 @@ describe "Singleton Job Queue" do
           Delayed::Job.reserve(worker2)
 
           # There should be three jobs on the queue, one locked singleton, one not locked singleton, one locked non-singleton
-          expect(Delayed::Job.where(queue: "singleton_#{queue_name}").count).to eq(2)
-          expect(Delayed::Job.where(queue: "singleton_#{queue_name}", locked_by: worker1.name).count).to eq(1)
-          expect(Delayed::Job.where(queue: "singleton_#{queue_name}", locked_by: nil).count).to eq(1)
-          expect(Delayed::Job.where(queue: different_queue_name).count).to eq(1)
-          expect(Delayed::Job.where(queue: different_queue_name, locked_by: worker2.name).count).to eq(1)
+          expect(Delayed::Job.where(singleton: queue_name).count).to eq(2)
+          expect(Delayed::Job.where(singleton: queue_name, locked_by: worker1.name).count).to eq(1)
+          expect(Delayed::Job.where(singleton: queue_name, locked_by: nil).count).to eq(1)
+          expect(Delayed::Job.where(singleton: different_queue_name).count).to eq(1)
+          expect(Delayed::Job.where(singleton: different_queue_name, locked_by: worker2.name).count).to eq(1)
         end
       end
 
@@ -124,11 +124,11 @@ describe "Singleton Job Queue" do
           Delayed::Job.reserve(worker2)
 
           # There should be three jobs on the queue, one locked singleton, one not locked singleton, one locked null
-          expect(Delayed::Job.where(queue: "singleton_#{queue_name}").count).to eq(2)
-          expect(Delayed::Job.where(queue: "singleton_#{queue_name}", locked_by: worker1.name).count).to eq(1)
-          expect(Delayed::Job.where(queue: "singleton_#{queue_name}", locked_by: nil).count).to eq(1)
-          expect(Delayed::Job.where(queue: nil).count).to eq(1)
-          expect(Delayed::Job.where(queue: nil, locked_by: worker2.name).count).to eq(1)
+          expect(Delayed::Job.where(singleton: queue_name).count).to eq(2)
+          expect(Delayed::Job.where(singleton: queue_name, locked_by: worker1.name).count).to eq(1)
+          expect(Delayed::Job.where(singleton: queue_name, locked_by: nil).count).to eq(1)
+          expect(Delayed::Job.where(singleton: nil).count).to eq(1)
+          expect(Delayed::Job.where(singleton: nil, locked_by: worker2.name).count).to eq(1)
         end
       end
     end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define do
     table.datetime :failed_at
     table.string   :locked_by
     table.string   :queue
+    table.string   :singleton
     table.timestamps
   end
 


### PR DESCRIPTION
@kbarrette - In order to split the queues into interactive and non-interactive variants we need to give the singleton queue indicator its own column, because there is a job that needs to be both a singleton and interactive (the store/MID provisioning job on grs_integration).

See https://trello.com/c/2lUi8y8B
