### PR TITLE
Now performing tagged logging on invoke_job.

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -29,10 +29,14 @@ module Delayed
 
         # Override #invoke_job so that there is tagged logging.
         def invoke_job
-          Rails.logger.tag(self.name) do
-            Rails.logger.info("Entering job")
+          if defined?(Rails)
+            Rails.logger.tag(self.name) do
+              Rails.logger.info("Entering job")
+              super
+              Rails.logger.info("Exiting job")
+            end
+          else
             super
-            Rails.logger.info("Exiting job")
           end
         end
 


### PR DESCRIPTION
@tucker250 

[`Delayed::Backend::Base#name`](https://github.com/collectiveidea/delayed_job/blob/master/lib/delayed/backend/base.rb#L75) seemed like a good candidate for the logging context.

Also, you'll notice that I'm using `Rails.logger`. This is because the `Delayed::Backend::Base` module cannot access `Delayed::Worker#logger`.

Let me know if you've got any questions.
