### PR TITLE
Don't fail to destroy a record if it cannot be deserialized

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -30,6 +30,10 @@ module Delayed
           if payload_object.respond_to?(:singleton_queue_name)
             self.class.where(:singleton => payload_object.singleton_queue_name).where("id != ?", id).delete_all
           end
+        rescue Delayed::DeserializationError => ex
+          if defined? Rails
+            Rails.logger.error("Unable to clear singleton queue for job: #{inspect} due to error: #{ex.message}")
+          end
         end
 
         def destroy

--- a/spec/delayed/backend/active_record_spec.rb
+++ b/spec/delayed/backend/active_record_spec.rb
@@ -89,6 +89,16 @@ describe Delayed::Backend::ActiveRecord::Job do
     end
   end
 
+  describe "#destroy" do
+    it "succeeds even if the payload_object is corrupt" do
+      allow(YAML).to receive(:load_dj).and_raise(ArgumentError)
+      subject.handler = "handler"
+      subject.save!
+
+      expect { subject.destroy }.to_not raise_error
+    end
+  end
+
   describe "reserve_with_scope" do
     let(:worker) { double(name: "worker01", read_ahead: 1) }
     let(:scope)  { double(limit: limit, where: double(update_all: nil)) }


### PR DESCRIPTION
@ermanc 

https://trello.com/c/e4CTWxvp

This is step one of the fix for the delayed_job serialization error that we hit last night. It prevents a deserialization error from preventing a job from getting deleted.